### PR TITLE
Check whether item.1 is a number instead of mapping to bool

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ pub struct DbConn(SqliteConnection);
 #[derive(Debug, Serialize)]
 struct Context {
     winner: Option<Item>,
-    items: Vec<(Item, bool)>,
+    items: Vec<(Item, Option<i32>)>,
 }
 
 impl Context {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -87,7 +87,7 @@ impl NewUser {
 }
 
 impl Item {
-    pub fn for_user(uid: i32, conn: &SqliteConnection) -> Vec<(Item, bool)> {
+    pub fn for_user(uid: i32, conn: &SqliteConnection) -> Vec<(Item, Option<i32>)> {
         all_items
             .left_join(
                 self::schema::votes::table
@@ -98,9 +98,6 @@ impl Item {
             .select((self::schema::items::all_columns, ordinal.nullable()))
             .load::<(Item, Option<i32>)>(conn)
             .unwrap()
-            .into_iter()
-            .map(|(i, ord)| (i, ord.map(|_| true).unwrap_or(false)))
-            .collect()
     }
 }
 

--- a/templates/vote.html.tera
+++ b/templates/vote.html.tera
@@ -30,7 +30,7 @@
 </style>
 <div id="ballot" class="list-group mt-3">
     {% for item in items %}
-    {% if item.1 %}
+    {% if item.1 is number %}
     {% if not item.0.done %}
     <div class="list-group-item list-group-item-action flex-column align-items-start" data-id="{{ item.0.id }}">
         <h5 class="mb-1">{{ item.0.title }}</h5>
@@ -43,7 +43,7 @@
     <div class="list-group-item list-group-item-action list-group-item-dark" data-id="void">I do not want to vote for the following:</div>
 
     {% for item in items %}
-    {% if not item.1 %}
+    {% if not item.1 is number %}
     {% if not item.0.done %}
     <div class="list-group-item list-group-item-action flex-column align-items-start" data-id="{{ item.0.id }}">
         <h5 class="mb-1">{{ item.0.title }}</h5>


### PR DESCRIPTION
Since the ID will always be a number if it exists, and null otherwise, it is enough to just check that the field is a number.  Since both `0` and `null` are falsy values it's not possible to just check whether the value is true, and it seems it's not possible to explicitly check whether something is or isn't null?

You originally tried to use `if item.1 is defined` and then checking if they're undefined for the unvoted ones.  This doesn't work since defined really does check whether the variable is defined.  A variable defined to be null is still defined.